### PR TITLE
ci: refine GitHub Actions workflow with build & test stages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,25 +4,56 @@ on:
     push:
         branches:
             - master
+            - dev
             - 'feature/*'
     pull_request:
         branches:
             - master
+            - dev
 
 jobs:
     build:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+            -   name: Checkout code
+                uses: actions/checkout@v4
 
-            - name: Set up JDK 24
-              uses: actions/setup-java@v4
-              with:
-                  java-version: '24'
-                  distribution: 'temurin'
-                  cache: maven
+            -   name: Set up JDK 24
+                uses: actions/setup-java@v4
+                with:
+                    java-version: '24'
+                    distribution: 'temurin'
+                    cache: maven
 
-            - name: Build with Maven
-              run: mvn clean install
+            -   name: Build with Maven (skip tests)
+                run: mvn clean package -DskipTests
+
+            -   name: Upload build artifact
+                uses: actions/upload-artifact@v4
+                with:
+                    name: app-jar
+                    path: target/*.jar
+
+    test:
+        runs-on: ubuntu-latest
+        needs: build
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v4
+
+            -   name: Set up JDK 24
+                uses: actions/setup-java@v4
+                with:
+                    java-version: '24'
+                    distribution: 'temurin'
+                    cache: maven
+
+            -   name: Download build artifact
+                uses: actions/download-artifact@v4
+                with:
+                    name: app-jar
+
+            -   name: Run tests
+                run: mvn test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,13 @@ jobs:
                     cache: maven
 
             -   name: Build with Maven (skip tests)
-                run: mvn clean package -DskipTests
+                run: mvn clean install -DskipTests
 
             -   name: Upload build artifact
                 uses: actions/upload-artifact@v4
                 with:
-                    name: app-jar
-                    path: target/*.jar
+                    name: platformone-jars
+                    path: '**/target/*.jar'
 
     test:
         runs-on: ubuntu-latest
@@ -53,7 +53,8 @@ jobs:
             -   name: Download build artifact
                 uses: actions/download-artifact@v4
                 with:
-                    name: app-jar
+                    name: platformone-jars
+                    path: target
 
             -   name: Run tests
                 run: mvn test


### PR DESCRIPTION
- Split pipeline into two jobs: build (skip tests) and test (run only tests)
- Cache Maven dependencies for faster builds
- Upload JAR from build stage and reuse in test stage
- Run workflow on pushes and PRs targeting master, dev, and feature/* branches
- Support new branch strategy with dev branch for integration before merging to master