### PR TITLE
ci: start containers before running tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,4 @@ jobs:
 
             -   name: Stop containers
                 if: always()
-                run: |
-                    chmod +x scripts/kafka-stop
-                    ./scripts/kafka-stop
+                run: make docker-stop


### PR DESCRIPTION
- Updated CI workflow  to start required containers before test execution